### PR TITLE
HTBHF-2575 Add utility class for building HTTP get requests with headers for calling DWP API.

### DIFF
--- a/common_dwp_api/build.gradle
+++ b/common_dwp_api/build.gradle
@@ -28,7 +28,7 @@ targetCompatibility = 1.11
 repositories {
     mavenCentral()
     maven {
-        url  "https://dl.bintray.com/departmentofhealth-htbhf/maven"
+        url "https://dl.bintray.com/departmentofhealth-htbhf/maven"
     }
 }
 
@@ -39,8 +39,8 @@ dependencies {
     implementation "javax.validation:validation-api:2.0.1.Final"
     implementation "org.hibernate.validator:hibernate-validator:6.1.0.Final"
     implementation "org.glassfish:javax.el:3.0.1-b11"
+    implementation "org.springframework:spring-web:${springVersion}"
 
-    testImplementation "org.springframework:spring-web:${springVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"

--- a/common_dwp_api/src/main/java/uk/gov/dhsc/htbhf/dwp/http/v2/GetRequestBuilder.java
+++ b/common_dwp_api/src/main/java/uk/gov/dhsc/htbhf/dwp/http/v2/GetRequestBuilder.java
@@ -1,0 +1,54 @@
+package uk.gov.dhsc.htbhf.dwp.http.v2;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import uk.gov.dhsc.htbhf.dwp.model.v2.DWPEligibilityRequestV2;
+import uk.gov.dhsc.htbhf.dwp.model.v2.PersonDTOV2;
+
+import java.time.LocalDate;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static uk.gov.dhsc.htbhf.dwp.http.v2.HeaderName.*;
+
+/**
+ * Utility used to build up a GET request with headers for calling the DWP API.
+ */
+public class GetRequestBuilder {
+
+    /**
+     * Builds the HTTP request with headers from the given request. Any values that are not provided will
+     * result in the header being omitted from the request. Any dates will be formatted using
+     * java.time.format.DateTimeFormatter.ISO_LOCAL_DATE.
+     *
+     * @param eligibilityRequest The request to take values from and add as headers to the request.
+     * @return The built HTTP entity.
+     */
+    public HttpEntity buildRequestWithHeaders(DWPEligibilityRequestV2 eligibilityRequest) {
+        PersonDTOV2 person = eligibilityRequest.getPerson();
+        HttpHeaders httpHeaders = new HttpHeaders();
+        addHeaderIfNotNull(httpHeaders, SURNAME, person.getSurname());
+        addHeaderIfNotNull(httpHeaders, NINO, person.getNino());
+        addHeaderIfNotNull(httpHeaders, DATE_OF_BIRTH, nullSafeDateFormat(person.getDateOfBirth()));
+        addHeaderIfNotNull(httpHeaders, ELIGIBILITY_END_DATE, nullSafeDateFormat(eligibilityRequest.getEligibilityEndDate()));
+        addHeaderIfNotNull(httpHeaders, ADDRESS_LINE_1, person.getAddressLine1());
+        addHeaderIfNotNull(httpHeaders, POSTCODE, person.getPostcode());
+        addHeaderIfNotNull(httpHeaders, EMAIL_ADDRESS, person.getEmailAddress());
+        addHeaderIfNotNull(httpHeaders, MOBILE_PHONE_NUMBER, person.getMobilePhoneNumber());
+        addHeaderIfNotNull(httpHeaders, PREGNANT_DEPENDENT_DOB, nullSafeDateFormat(person.getPregnantDependentDob()));
+        addHeaderIfNotNull(httpHeaders, UC_MONTHLY_INCOME_THRESHOLD, String.valueOf(eligibilityRequest.getUcMonthlyIncomeThresholdInPence()));
+        return new HttpEntity<>(httpHeaders);
+    }
+
+    private String nullSafeDateFormat(LocalDate dateToFormat) {
+        if (dateToFormat != null) {
+            return ISO_LOCAL_DATE.format(dateToFormat);
+        }
+        return null;
+    }
+
+    private void addHeaderIfNotNull(HttpHeaders httpHeaders, HeaderName headerName, String headerValue) {
+        if (headerValue != null) {
+            httpHeaders.set(headerName.getHeader(), headerValue);
+        }
+    }
+}

--- a/common_dwp_api/src/main/java/uk/gov/dhsc/htbhf/dwp/http/v2/HeaderName.java
+++ b/common_dwp_api/src/main/java/uk/gov/dhsc/htbhf/dwp/http/v2/HeaderName.java
@@ -1,0 +1,24 @@
+package uk.gov.dhsc.htbhf.dwp.http.v2;
+
+public enum HeaderName {
+    SURNAME("surname"),
+    NINO("nino"),
+    DATE_OF_BIRTH("dateOfBirth"),
+    ELIGIBILITY_END_DATE("eligibilityEndDate"),
+    ADDRESS_LINE_1("addressLine1"),
+    POSTCODE("postcode"),
+    EMAIL_ADDRESS("emailAddress"),
+    MOBILE_PHONE_NUMBER("mobilePhoneNumber"),
+    PREGNANT_DEPENDENT_DOB("pregnantDependentDob"),
+    UC_MONTHLY_INCOME_THRESHOLD("ucMonthlyIncomeThreshold");
+
+    private String header;
+
+    HeaderName(String header) {
+        this.header = header;
+    }
+
+    public String getHeader() {
+        return this.header;
+    }
+}

--- a/common_dwp_api/src/test/java/uk/gov/dhsc/htbhf/dwp/http/v2/GetRequestBuilderTest.java
+++ b/common_dwp_api/src/test/java/uk/gov/dhsc/htbhf/dwp/http/v2/GetRequestBuilderTest.java
@@ -1,0 +1,81 @@
+package uk.gov.dhsc.htbhf.dwp.http.v2;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import uk.gov.dhsc.htbhf.dwp.model.v2.DWPEligibilityRequestV2;
+import uk.gov.dhsc.htbhf.dwp.model.v2.PersonDTOV2;
+import uk.gov.dhsc.htbhf.dwp.testhelper.v2.PersonDTOV2TestDataFactory;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants.*;
+import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.DWPEligibilityRequestV2TestDataFactory.aValidDWPEligibilityRequestV2;
+import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.DWPEligibilityRequestV2TestDataFactory.aValidDWPEligibilityRequestV2WithPerson;
+
+class GetRequestBuilderTest {
+
+    private GetRequestBuilder builder = new GetRequestBuilder();
+
+    @Test
+    void buildRequestWithHeaders() {
+        //Given
+        DWPEligibilityRequestV2 request = aValidDWPEligibilityRequestV2();
+        //When
+        HttpEntity httpEntity = builder.buildRequestWithHeaders(request);
+        //Then
+        assertThat(httpEntity).isNotNull();
+        assertThat(httpEntity.hasBody()).isFalse();
+        HttpHeaders headers = httpEntity.getHeaders();
+        assertCommonHeadersCorrect(headers);
+        assertThat(headers.getFirst("emailAddress")).isEqualTo(HOMER_EMAIL);
+        assertThat(headers.getFirst("pregnantDependentDob")).isEqualTo(MAGGIE_DATE_OF_BIRTH_STRING);
+    }
+
+    @Test
+    void buildRequestWithMissingHeader() {
+        //Given
+        PersonDTOV2 person = PersonDTOV2TestDataFactory.aPersonDTOV2WithEmailAddress(null);
+        DWPEligibilityRequestV2 request = aValidDWPEligibilityRequestV2WithPerson(person);
+        //When
+        HttpEntity httpEntity = builder.buildRequestWithHeaders(request);
+        //Then
+        assertThat(httpEntity).isNotNull();
+        assertThat(httpEntity.hasBody()).isFalse();
+        HttpHeaders headers = httpEntity.getHeaders();
+        assertCommonHeadersCorrect(headers);
+        assertThat(headers.containsKey("emailAddress")).isFalse();
+        assertThat(headers.getFirst("pregnantDependentDob")).isEqualTo(MAGGIE_DATE_OF_BIRTH_STRING);
+    }
+
+    @Test
+    void buildRequestWithMissingDateHeader() {
+        //Given
+        PersonDTOV2 person = PersonDTOV2TestDataFactory.aPersonDTOV2WithPregnantDependantDob(null);
+        DWPEligibilityRequestV2 request = aValidDWPEligibilityRequestV2WithPerson(person);
+        //When
+        HttpEntity httpEntity = builder.buildRequestWithHeaders(request);
+        //Then
+        assertThat(httpEntity).isNotNull();
+        assertThat(httpEntity.hasBody()).isFalse();
+        HttpHeaders headers = httpEntity.getHeaders();
+        assertCommonHeadersCorrect(headers);
+        assertThat(headers.getFirst("emailAddress")).isEqualTo(HOMER_EMAIL);
+        assertThat(headers.containsKey("pregnantDependentDob")).isFalse();
+    }
+
+    private void assertCommonHeadersCorrect(HttpHeaders headers) {
+        LocalDate eligibilityEndDate = LocalDate.now().plusDays(28);
+        String eligibilityEndDateString = DateTimeFormatter.ISO_LOCAL_DATE.format(eligibilityEndDate);
+        assertThat(headers.getFirst("surname")).isEqualTo(SIMPSON_SURNAME);
+        assertThat(headers.getFirst("nino")).isEqualTo(HOMER_NINO_V2);
+        assertThat(headers.getFirst("dateOfBirth")).isEqualTo(HOMER_DATE_OF_BIRTH_STRING);
+        assertThat(headers.getFirst("eligibilityEndDate")).isEqualTo(eligibilityEndDateString);
+        assertThat(headers.getFirst("addressLine1")).isEqualTo(SIMPSONS_ADDRESS_LINE_1);
+        assertThat(headers.getFirst("postcode")).isEqualTo(SIMPSONS_POSTCODE);
+        assertThat(headers.getFirst("mobilePhoneNumber")).isEqualTo(HOMER_MOBILE);
+        assertThat(headers.getFirst("ucMonthlyIncomeThreshold")).isEqualTo(String.valueOf(UC_MONTHLY_INCOME_THRESHOLD_IN_PENCE));
+    }
+}


### PR DESCRIPTION
This has been lifted out of DWP API for common use in DWP API and eligibility service. Next PR will remove it from DWP API service.