### PR TITLE
HTBHF-2568 Add isNotEligibile method to IdentityAndEligibilityResponse.

### DIFF
--- a/common_dwp_api/src/main/java/uk/gov/dhsc/htbhf/dwp/model/v2/IdentityAndEligibilityResponse.java
+++ b/common_dwp_api/src/main/java/uk/gov/dhsc/htbhf/dwp/model/v2/IdentityAndEligibilityResponse.java
@@ -1,6 +1,7 @@
 package uk.gov.dhsc.htbhf.dwp.model.v2;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -49,4 +50,14 @@ public class IdentityAndEligibilityResponse {
 
     @JsonProperty("identityStatus")
     private final IdentityOutcome identityStatus;
+
+    /**
+     * Determine whether the eligibility outcome is considered eligible or not.
+     *
+     * @return Whether the eligibility outcome is considered eligible or not.
+     */
+    @JsonIgnore
+    public boolean isNotEligible() {
+        return EligibilityOutcome.CONFIRMED != eligibilityStatus;
+    }
 }

--- a/common_dwp_api/src/test/java/uk/gov/dhsc/htbhf/dwp/model/v2/IdentityAndEligibilityResponseTest.java
+++ b/common_dwp_api/src/test/java/uk/gov/dhsc/htbhf/dwp/model/v2/IdentityAndEligibilityResponseTest.java
@@ -1,0 +1,35 @@
+package uk.gov.dhsc.htbhf.dwp.model.v2;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchFailedResponse;
+import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
+import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityNotConfirmedResponse;
+
+class IdentityAndEligibilityResponseTest {
+
+    @Test
+    void shouldBeEligibleForConfirmedEligibilityOutcome() {
+        IdentityAndEligibilityResponse response = anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches();
+        assertThat(response.isNotEligible()).isFalse();
+    }
+
+    @Test
+    void shouldBeIneligibleForNotSetEligibilityOutcome() {
+        IdentityAndEligibilityResponse response = anIdentityMatchFailedResponse();
+        assertThat(response.isNotEligible()).isTrue();
+    }
+
+    @Test
+    void shouldBeIneligibleForNotConfirmedEligibilityOutcome() {
+        IdentityAndEligibilityResponse response = anIdentityMatchedEligibilityNotConfirmedResponse();
+        assertThat(response.isNotEligible()).isTrue();
+    }
+
+    @Test
+    void shouldBeIneligibleEligibilityOutcomeNotSet() {
+        IdentityAndEligibilityResponse response = IdentityAndEligibilityResponse.builder().build();
+        assertThat(response.isNotEligible()).isTrue();
+    }
+}

--- a/common_dwp_api_test/src/main/java/uk/gov/dhsc/htbhf/dwp/testhelper/v2/IdentityAndEligibilityResponseTestDataFactory.java
+++ b/common_dwp_api_test/src/main/java/uk/gov/dhsc/htbhf/dwp/testhelper/v2/IdentityAndEligibilityResponseTestDataFactory.java
@@ -12,19 +12,7 @@ import static uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants.NO_HOUSEHOLD_IDENTI
 public class IdentityAndEligibilityResponseTestDataFactory {
 
     public static IdentityAndEligibilityResponse anIdentityMatchFailedResponse() {
-        return IdentityAndEligibilityResponse.builder()
-                .identityStatus(IdentityOutcome.NOT_MATCHED)
-                .eligibilityStatus(EligibilityOutcome.NOT_SET)
-                .qualifyingBenefits(QualifyingBenefits.NOT_SET)
-                .mobilePhoneMatch(VerificationOutcome.NOT_SET)
-                .emailAddressMatch(VerificationOutcome.NOT_SET)
-                .addressLine1Match(VerificationOutcome.NOT_SET)
-                .postcodeMatch(VerificationOutcome.NOT_SET)
-                .pregnantChildDOBMatch(VerificationOutcome.NOT_SET)
-                .householdIdentifier(NO_HOUSEHOLD_IDENTIFIER_PROVIDED)
-                .dobOfChildrenUnder4(emptyList())
-                .deathVerificationFlag(DeathVerificationFlag.N_A)
-                .build();
+        return defaultBuilderWithIdentityNotMatchedValues().build();
     }
 
     public static IdentityAndEligibilityResponse anIdentityMatchedEligibilityNotConfirmedResponse() {
@@ -116,6 +104,21 @@ public class IdentityAndEligibilityResponseTestDataFactory {
                 .deathVerificationFlag(DeathVerificationFlag.N_A)
                 .dobOfChildrenUnder4(childrenDobs)
                 .build();
+    }
+
+    public static IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder defaultBuilderWithIdentityNotMatchedValues() {
+        return IdentityAndEligibilityResponse.builder()
+                .identityStatus(IdentityOutcome.NOT_MATCHED)
+                .eligibilityStatus(EligibilityOutcome.NOT_SET)
+                .qualifyingBenefits(QualifyingBenefits.NOT_SET)
+                .mobilePhoneMatch(VerificationOutcome.NOT_SET)
+                .emailAddressMatch(VerificationOutcome.NOT_SET)
+                .addressLine1Match(VerificationOutcome.NOT_SET)
+                .postcodeMatch(VerificationOutcome.NOT_SET)
+                .pregnantChildDOBMatch(VerificationOutcome.NOT_SET)
+                .householdIdentifier(NO_HOUSEHOLD_IDENTIFIER_PROVIDED)
+                .dobOfChildrenUnder4(emptyList())
+                .deathVerificationFlag(DeathVerificationFlag.N_A);
     }
 
 }


### PR DESCRIPTION
This is in preparation for removing QualifyingBenefitEligibilityStatus from the claimant-service.

Also added a method to IdentityAndEligibilityResponseTestDataFactory which returns the builder so we don't have to add extra methods to this test data factory every time we want to change a value.